### PR TITLE
[chore|sde] bump application version 2.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 
 ## 0.0.7
 ### Change
-* changed to v2.0.9 docker image version.
+* changed to v2.0.11 docker image version.
 * added license header.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple-Data-Exchanger helm chart.
 
+## 0.0.7
+### Change
+* changed to v2.0.9 docker image version.
+
+
 ## 0.0.6
 ### Change
 * changed to v2.0.8 docker image version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 ## 0.0.7
 ### Change
 * changed to v2.0.9 docker image version.
+* added license header.
 
 
 ## 0.0.6

--- a/README.md
+++ b/README.md
@@ -10,13 +10,34 @@ This helm chart installs the SDE application which consists of
 
 To install the chart with the release name portal:
 
-``` $ helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev ```
-
-```$ helm install simpledataexchanger tractusx-dev/simpledataexchanger```
-
+ ```shell
+  helm repo add sde-repo https://eclipse-tractusx.github.io/charts/dev 
+  helm search repo sde-repo/sde
+  helm install -f your-values.yaml release-name sde/sde-app 
+ ``` 
 ## Requirements
 
 | Repository                                         | Name       | Version  |
 |--------------------------------------------------- |------------|--------- |
 | `https://charts.bitnami.com/bitnami`               | postgresql | 11.9.13  |                     
 	
+### Licenses
+For used licenses, please see the [NOTICE](https://github.com/eclipse-tractusx/managed-simple-data-exchanger/blob/main/NOTICE.md).
+
+## Notice for Docker image
+
+This application provides container images for demonstration purposes.
+
+DockerHub: https://hub.docker.com/r/tractusx/managed-simple-data-exchanger-backend
+
+DockerHub: https://hub.docker.com/r/tractusx/managed-simple-data-exchanger-frontend 
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/managed-simple-data-exchanger
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Project license: [Apache License, Version 2.0] https://github.com/eclipse-tractusx/managed-simple-data-exchanger/blob/main/LICENSE
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/charts/chart-testing-config.yaml
+++ b/charts/chart-testing-config.yaml
@@ -1,3 +1,22 @@
+#################################################################################
+# Copyright (c) 2023 T-Systems International GmbH
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
 validate-maintainers: false
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -32,12 +32,12 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: 0.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.8"
+appVersion: "2.0.9"
 
 dependencies:
   - condition: sdepostgresql.enabled

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -37,7 +37,7 @@ version: 0.0.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.9"
+appVersion: "2.0.11"
 
 dependencies:
   - condition: sdepostgresql.enabled

--- a/charts/simpledataexchanger/README.md
+++ b/charts/simpledataexchanger/README.md
@@ -66,7 +66,7 @@ A Helm chart for Kubernetes
 | frontend.configuration.properties | string | `"REACT_APP_API_URL=\nREACT_APP_KEYCLOAK_URL=\nREACT_APP_KEYCLOAK_REALM=\nREACT_APP_CLIENT_ID=\nREACT_APP_FILESIZE=\nREACT_APP_DEFAULT_COMPANY_BPN="` |  |
 | frontend.fullnameOverride | string | `""` |  |
 | frontend.image.pullPolicy | string | `"Always"` |  |
-| frontend.image.repository | string | `"gtractusx/managed-simple-data-exchanger-frontend"` |  |
+| frontend.image.repository | string | `"tractusx/managed-simple-data-exchanger-frontend"` |  |
 | frontend.image.tag | string | `""` |  |
 | frontend.imagePullSecrets | list | `[]` |  |
 | frontend.ingresses[0].annotations."kubernetes.io/tls-acme" | string | `"true"` |  |

--- a/charts/simpledataexchanger/README.md
+++ b/charts/simpledataexchanger/README.md
@@ -28,7 +28,7 @@ A Helm chart for Kubernetes
 | backend.configuration.properties | string | `"keycloak.clientid=default\nspring.security.oauth2.resourceserver.jwt.issuer-uri=default\nmanagement.endpoint.health.probes.enabled=true\nmanagement.health.readinessstate.enabled=true\nmanagement.health.livenessstate.enabled=true\nmanagement.endpoints.web.exposure.include=*\nspring.lifecycle.timeout-per-shutdown-phase=30s\nlogging.level.org.springframework.security.web.csrf=INFO\nspring.servlet.multipart.enabled=true\nspring.main.allow-bean-definition-overriding=true\nspring.servlet.multipart.file-size-threshold=2KB\nspring.servlet.multipart.max-file-size=200MB\nspring.servlet.multipart.max-request-size=215MB\nserver.servlet.context-path=/api\nspring.flyway.baseline-on-migrate=true\nspring.flyway.locations=classpath:/flyway\nspring.datasource.driver-class-name=org.postgresql.Driver\nspring.jpa.hibernate.ddl-auto=update\nspring.jpa.open-in-view=false\nfile.upload-dir=./temp/\nlogging.level.org.apache.http=info\nlogging.level.root=info\ndigital-twins.hostname=default\ndigital-twins.authentication.url=default\ndigital-twins.authentication.clientId=default\ndigital-twins.authentication.clientSecret=default\ndigital-twins.authentication.grantType=client_credentials\nedc.hostname=default\nedc.apiKeyHeader=default\nedc.apiKey=default\nedc.consumer.hostname=default\nedc.consumer.apikeyheader=default\nedc.consumer.apikey=default\nedc.consumer.datauri=/api/v1/ids/data\ndft.hostname=default\ndft.apiKeyHeader=default\ndft.apiKey=default\nmanufacturerId=default\npartner.pool.hostname=default\nconnector.discovery.token-url=default\nconnector.discovery.clientId=default\nconnector.discovery.clientSecret=default\nportal.backend.hostname=default\nspringdoc.api-docs.path=/api-docs"` |  |
 | backend.fullnameOverride | string | `""` |  |
 | backend.image.pullPolicy | string | `"Always"` |  |
-| backend.image.repository | string | `"ghcr.io/catenax-ng/tx-managed-simple-data-exchanger-backend"` |  |
+| backend.image.repository | string | `"tractusx/managed-simple-data-exchanger-backend"` |  |
 | backend.image.tag | string | `""` |  |
 | backend.imagePullSecrets | list | `[]` |  |
 | backend.ingresses[0].annotations | object | `{}` |  |
@@ -66,7 +66,7 @@ A Helm chart for Kubernetes
 | frontend.configuration.properties | string | `"REACT_APP_API_URL=\nREACT_APP_KEYCLOAK_URL=\nREACT_APP_KEYCLOAK_REALM=\nREACT_APP_CLIENT_ID=\nREACT_APP_FILESIZE=\nREACT_APP_DEFAULT_COMPANY_BPN="` |  |
 | frontend.fullnameOverride | string | `""` |  |
 | frontend.image.pullPolicy | string | `"Always"` |  |
-| frontend.image.repository | string | `"ghcr.io/catenax-ng/tx-managed-simple-data-exchanger-frontend"` |  |
+| frontend.image.repository | string | `"gtractusx/managed-simple-data-exchanger-frontend"` |  |
 | frontend.image.tag | string | `""` |  |
 | frontend.imagePullSecrets | list | `[]` |  |
 | frontend.ingresses[0].annotations."kubernetes.io/tls-acme" | string | `"true"` |  |

--- a/charts/simpledataexchanger/templates/_helpers.tpl
+++ b/charts/simpledataexchanger/templates/_helpers.tpl
@@ -1,3 +1,23 @@
+#################################################################################
+# Copyright (c) 2023 T-Systems International GmbH
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/simpledataexchanger/values.yaml
+++ b/charts/simpledataexchanger/values.yaml
@@ -59,7 +59,6 @@ backend:
         - ALL
     runAsNonRoot: true
     runAsUser: 1001
-    fsGroup: 1001
 
   service:
     type: ClusterIP

--- a/charts/simpledataexchanger/values.yaml
+++ b/charts/simpledataexchanger/values.yaml
@@ -35,7 +35,7 @@ sdepostgresql:
 
 backend:
   image:
-    repository: ghcr.io/catenax-ng/tx-managed-simple-data-exchanger-backend
+    repository: tractusx/managed-simple-data-exchanger-backend
     pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -187,7 +187,7 @@ backend:
 
 frontend:
   image:
-    repository: ghcr.io/catenax-ng/tx-managed-simple-data-exchanger-frontend
+    repository: tractusx/managed-simple-data-exchanger-frontend
     pullPolicy: Always
       # Overrides the image tag whose default is the chart appVersion.
     tag: ""


### PR DESCRIPTION
## Description

- changed to v2.0.11 docker image version.
- added license header.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
