### PR TITLE
[Chore|sde-v2.1.0] Dependency update for helm 

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           cd charts/simpledataexchanger
           helm repo add bitnami https://charts.bitnami.com/bitnami          
-          helm dependency update
+          helm dependency update charts/simpledataexchanger
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
           helm install simpledataexchanger charts/simpledataexchanger --namespace install --create-namespace
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -90,9 +90,11 @@ jobs:
         run: ct install --charts charts/simpledataexchanger --config charts/chart-testing-config.yaml
         if: ${{ env.CHART_CHANGED == 'true' }}
 
-      - name: Run helm install
+      - name: Run helm install and dependency update
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          cd charts/simpledataexchanger
+          helm repo add bitnami https://charts.bitnami.com/bitnami          
+          helm dependency update
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
           helm install simpledataexchanger charts/simpledataexchanger --namespace install --create-namespace
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -92,10 +92,9 @@ jobs:
 
       - name: Run helm install and dependency update
         run: |
-          cd charts/simpledataexchanger
           helm repo add bitnami https://charts.bitnami.com/bitnami          
-          helm dependency update charts/simpledataexchanger
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+          helm dependency update charts/simpledataexchanger 
           helm install simpledataexchanger charts/simpledataexchanger --namespace install --create-namespace
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
         


### PR DESCRIPTION
## Description

#18  Fixed for helm chart dependency.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
