### PR TITLE
[chore | Bumped version for chart and app version]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple-Data-Exchanger helm chart.
 
+## 0.0.9
+### Change
+* changed to v2.1.1 docker image version.
+
 ## 0.0.8
 ### Change
 * changed to v2.1.0 docker image version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,5 +42,3 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 ### Change
 * added product helm chart for SDE, combining frontend and backend chart.
 * moved repository to eclipse-tractusx.
-
-

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -32,12 +32,12 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.0"
+appVersion: "2.1.1"
 
 dependencies:
   - condition: sdepostgresql.enabled


### PR DESCRIPTION
## Description
-  0.0.9 helm chart version and app version 2.1.1

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
