### PR TITLE
[Chore|SDE|Helm-0.1.0] Helm charts update for AppV 2.3.1 | vulnerability, image permission fix & random password generation.

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -41,7 +41,7 @@ on:
         upgrade_from:
           description: 'chart version to upgrade from'
           # chart version from 3.1 release as default
-          default: '2.0.0'
+          default: '0.0.9'
           required: false
           type: string
 
@@ -98,11 +98,11 @@ jobs:
           helm install simpledataexchanger charts/simpledataexchanger --namespace install --create-namespace
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
         
-#      - name: Run helm upgrade
-#        run: |
-#          helm repo add bitnami https://charts.bitnami.com/bitnami
-#          helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-#          helm install simpledataexchanger tractusx-dev/simpledataexchanger --version ${{ github.event.inputs.upgrade_from || '2.0.0' }} --namespace upgrade --create-namespace
-#          helm dependency update charts/simpledataexchanger
-#          helm upgrade simpledataexchanger charts/simpledataexchanger --namespace upgrade
-#        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
+      - name: Run helm upgrade
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+          helm install simpledataexchanger tractusx-dev/simpledataexchanger --version ${{ github.event.inputs.upgrade_from || '0.0.9' }} --namespace upgrade --create-namespace
+          helm dependency update charts/simpledataexchanger
+          helm upgrade simpledataexchanger charts/simpledataexchanger --namespace upgrade
+        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -34,13 +34,13 @@ on:
       inputs:
         node_image:
           description: 'kindest/node image for k8s kind cluster'
-          # k8s version from 3.1 release as default
+          # k8s version from 3.2 release as default
           default: 'kindest/node:v1.24.6'
           required: false
           type: string
         upgrade_from:
           description: 'chart version to upgrade from'
-          # chart version from 3.1 release as default
+          # chart version from 3.2 release as default
           default: '0.0.9'
           required: false
           type: string

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-          helm install simpledataexchanger tractusx-dev/simpledataexchanger --version ${{ github.event.inputs.upgrade_from || '0.0.9' }} --namespace upgrade --create-namespace
+          helm install simpledataexchanger tractusx-dev/sde --version ${{ github.event.inputs.upgrade_from || '0.0.9' }} --namespace upgrade --create-namespace
           helm dependency update charts/simpledataexchanger
           helm upgrade simpledataexchanger charts/simpledataexchanger --namespace upgrade
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple-Data-Exchanger helm chart.
 
-## 0.0.10
+## 0.1.0 
 ### Added 
 * PostgreSQL random password generation.
+### Change
+* changed to v2.3.1 docker image version.
+* fixed custom user permission issue in docker image.
+* Veracode vulnerability fix in AppV- 2.3.1
 
+## 0.0.10 [non-release]
+### Added 
+* PostgreSQL random password generation.
 ### Change
 * changed to v2.3.0 docker image version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple-Data-Exchanger helm chart.
 
-## 1.0.0
+## 0.0.10
+### Added 
+* PostgreSQL random password generation.
+
 ### Change
 * changed to v2.3.0 docker image version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple-Data-Exchanger helm chart.
 
+## 1.0.0
+### Change
+* changed to v2.3.0 docker image version.
+
 ## 0.0.9
 ### Change
 * changed to v2.1.1 docker image version.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To install the chart with the release name portal:
 
 | Repository                                         | Name       | Version  |
 |--------------------------------------------------- |------------|--------- |
-| `https://charts.bitnami.com/bitnami`               | postgresql | 11.9.13  |                     
+| `https://charts.bitnami.com/bitnami`               | postgresql | 12.12.10 |                     
 	
 ### Licenses
 For used licenses, please see the [NOTICE](https://github.com/eclipse-tractusx/managed-simple-data-exchanger/blob/main/NOTICE.md).

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -32,12 +32,12 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.3.0"
+appVersion: "2.3.1"
 
 dependencies:
   - condition: sdepostgresql.enabled

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -32,16 +32,16 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.9
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.1"
+appVersion: "2.3.0"
 
 dependencies:
   - condition: sdepostgresql.enabled
     name: postgresql
     alias: sdepostgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 11.x.x
+    version: 12.x.x

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -32,7 +32,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 0.0.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/simpledataexchanger/README.md
+++ b/charts/simpledataexchanger/README.md
@@ -1,6 +1,6 @@
 # sde
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -12,7 +12,7 @@ A Helm chart for Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | sdepostgresql(postgresql) | 11.x.x |
+| https://charts.bitnami.com/bitnami | sdepostgresql(postgresql) | 12.12.10 |
 
 ## Values
 

--- a/charts/simpledataexchanger/templates/_helpers.tpl
+++ b/charts/simpledataexchanger/templates/_helpers.tpl
@@ -63,11 +63,74 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+backend Common labels
+*/}}
+{{- define "sde.backend.labels" -}}
+helm.sh/chart: {{ include "sde.chart" . }}
+{{ include "sde.backend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+frontend Common labels
+*/}}
+{{- define "sde.frontend.labels" -}}
+helm.sh/chart: {{ include "sde.chart" . }}
+{{ include "sde.frontend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "sde.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "sde.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+backend Selector labels
+*/}}
+{{- define "sde.backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sde.name" . }}-backend
+app.kubernetes.io/instance: {{ .Release.Name }}-backend
+{{- end }}
+
+{{/*
+frontend Selector labels
+*/}}
+{{- define "sde.frontend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sde.name" . }}-frontend
+app.kubernetes.io/instance: {{ .Release.Name }}-frontend
+{{- end }}
+
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sde.backend.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sde.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sde.frontend.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sde.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/simpledataexchanger/templates/configmap-backend.yaml
+++ b/charts/simpledataexchanger/templates/configmap-backend.yaml
@@ -23,7 +23,7 @@ metadata:
   name: {{ include "sde.fullname" . }}-backend-configmap
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
-    {{- include "sde.labels" . | nindent 4 }}
+    {{- include "sde.backend.labels" . | nindent 4 }}
 data:
   configuration.properties: |-
     {{- .Values.backend.configuration.properties | nindent 4 }}

--- a/charts/simpledataexchanger/templates/configmap-frontend.yaml
+++ b/charts/simpledataexchanger/templates/configmap-frontend.yaml
@@ -23,7 +23,7 @@ metadata:
   name: {{ include "sde.fullname" . }}-frontend-configmap
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
-    {{- include "sde.labels" . | nindent 4 }}
+    {{- include "sde.frontend.labels" . | nindent 4 }}
 data:
   configuration.properties: |-
     {{- .Values.frontend.configuration.properties | nindent 4 }}

--- a/charts/simpledataexchanger/templates/deployment-backend.yaml
+++ b/charts/simpledataexchanger/templates/deployment-backend.yaml
@@ -58,13 +58,25 @@ spec:
           ports:
           - containerPort: {{ .Values.backend.portContainer }}
           env:
+            - name: SPRING_DATASOURCE_USERNAME
+              value: {{ .Values.sdepostgresql.auth.username | required ".Values.sdepostgresql.auth.username is required" | quote }}
+            {{- if .Values.sdepostgresql.fullnameOverride }}
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://{{ .Values.sdepostgresql.fullnameOverride }}:{{ .Values.sdepostgresql.auth.port }}/{{ .Values.sdepostgresql.auth.database }}"
-            - name: SPRING_DATASOURCE_USERNAME
-              value: {{ .Values.sdepostgresql.auth.username | required ".Values.sdepostgresql.auth.username is required" | quote }}             
             - name: SPRING_DATASOURCE_PASSWORD
-              value: {{ .Values.sdepostgresql.auth.password | required ".Values.sdepostgresql.auth.password is required" | quote}}
-              
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sdepostgresql.fullnameOverride }}
+                  key: "password"
+            {{- else }}
+            - name: SPRING_DATASOURCE_URL
+              value: "jdbc:postgresql://{{ include "sde.fullname" . }}-sdepostgresql:{{ .Values.sdepostgresql.auth.port }}/{{ .Values.sdepostgresql.auth.database }}"
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sde.fullname" . }}-sdepostgresql
+                  key: "password"
+            {{- end }}    
           envFrom:
             - configMapRef:
                 name: {{ include "sde.fullname" . }}-backend-configmap

--- a/charts/simpledataexchanger/templates/deployment-backend.yaml
+++ b/charts/simpledataexchanger/templates/deployment-backend.yaml
@@ -24,14 +24,14 @@ metadata:
   name: {{ include "sde.fullname" . }}-backend
   namespace: {{ .Release.Namespace | default "default" | quote }}
   labels:
-    {{- include "sde.labels" . | nindent 4 }}
+    {{- include "sde.backend.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.backend.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "sde.selectorLabels" . | nindent 6 }}
+      {{- include "sde.backend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.backend.podAnnotations }}
@@ -39,7 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "sde.selectorLabels" . | nindent 8 }}
+        {{- include "sde.backend.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.backend.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/simpledataexchanger/templates/deployment-frontend.yaml
+++ b/charts/simpledataexchanger/templates/deployment-frontend.yaml
@@ -22,12 +22,12 @@ kind: Deployment
 metadata:
   name: {{ include "sde.fullname" . }}-frontend
   labels:
-    {{- include "sde.labels" . | nindent 4 }}
+    {{- include "sde.frontend.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "sde.selectorLabels" . | nindent 6 }}
+      {{- include "sde.frontend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.frontend.podAnnotations }}
@@ -35,7 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "sde.selectorLabels" . | nindent 8 }}
+        {{- include "sde.frontend.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.frontend.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/simpledataexchanger/templates/hpa-backend.yaml
+++ b/charts/simpledataexchanger/templates/hpa-backend.yaml
@@ -24,7 +24,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "sde.fullname" . }}-backend
   labels:
-    {{- include "sde.labels" . | nindent 4 }}
+    {{- include "sde.backend.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/simpledataexchanger/templates/hpa-frontend.yaml
+++ b/charts/simpledataexchanger/templates/hpa-frontend.yaml
@@ -24,7 +24,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "sde.fullname" . }}-frontend
   labels:
-    {{- include "sde.labels" . | nindent 4 }}
+    {{- include "sde.frontend.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/simpledataexchanger/templates/ingress-backend.yaml
+++ b/charts/simpledataexchanger/templates/ingress-backend.yaml
@@ -17,14 +17,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
-{{- $fullName := include "sde.fullname" . }}-backend
-{{- $labels := include "sde.labels" . | nindent 4 }}
+{{- $fullName := include "sde.fullname" . }}
+{{- $labels := include "sde.backend.labels" . | nindent 4 }}
 {{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $sdeEndpoints := .Values.backend.backend.endpoints }}
 {{- $namespace := .Release.Namespace }}
 {{- range .Values.backend.ingresses }}
 {{- if and .enabled .endpoints }}
-{{- $ingressName := printf "%s-%s" $fullName .hostname }}
+{{- $ingressName := printf "%s-backend-%s" $fullName .hostname }}
 ---
 {{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
@@ -83,7 +83,7 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $gitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-backend
                 port:
                   number: {{ $mapping.port }}
               {{- else }}

--- a/charts/simpledataexchanger/templates/ingress-frontend.yaml
+++ b/charts/simpledataexchanger/templates/ingress-frontend.yaml
@@ -17,14 +17,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
-{{- $fullName := include "sde.fullname" . }}-frontend
-{{- $labels := include "sde.labels" . | nindent 4 }}
+{{- $fullName := include "sde.fullname" . }}
+{{- $labels := include "sde.frontend.labels" . | nindent 4 }}
 {{- $gitVersion := .Capabilities.KubeVersion.GitVersion }}
 {{- $dftEndpoints := .Values.frontend.sde.endpoints }}
 {{- $namespace := .Release.Namespace }}
 {{- range .Values.frontend.ingresses }}
 {{- if and .enabled .endpoints }}
-{{- $ingressName := printf "%s-%s" $fullName .hostname }}
+{{- $ingressName := printf "%s-frontend-%s" $fullName .hostname }}
 ---
 {{- if semverCompare ">=1.19-0" $gitVersion }}
 apiVersion: networking.k8s.io/v1
@@ -83,7 +83,7 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $gitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-frontend
                 port:
                   number: {{ $mapping.port }}
               {{- else }}

--- a/charts/simpledataexchanger/templates/service-backend.yaml
+++ b/charts/simpledataexchanger/templates/service-backend.yaml
@@ -22,7 +22,7 @@ kind: Service
 metadata:
   name: {{ include "sde.fullname" . }}-backend
   labels:
-    {{- include "sde.labels" . | nindent 4 }}
+    {{- include "sde.backend.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.backend.service.type }}
   ports:
@@ -31,4 +31,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "sde.selectorLabels" . | nindent 4 }}
+    {{- include "sde.backend.selectorLabels" . | nindent 4 }}

--- a/charts/simpledataexchanger/templates/service-frontend.yaml
+++ b/charts/simpledataexchanger/templates/service-frontend.yaml
@@ -22,7 +22,7 @@ kind: Service
 metadata:
   name: {{ include "sde.fullname" . }}-frontend
   labels:
-    {{- include "sde.labels" . | nindent 4 }}
+    {{- include "sde.frontend.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.frontend.service.type }}
   ports:
@@ -31,5 +31,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "sde.selectorLabels" . | nindent 4 }}
+    {{- include "sde.frontend.selectorLabels" . | nindent 4 }}
 

--- a/charts/simpledataexchanger/templates/tests/test-connection-backend.yaml
+++ b/charts/simpledataexchanger/templates/tests/test-connection-backend.yaml
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "sde.fullname" . }}-backend-test-connection"
+  name: "{{ include "sde.fullname" . }}-frontend-test-connection"
   labels:
     {{- include "sde.labels" . | nindent 4 }}
   annotations:
@@ -30,5 +30,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "sde.fullname" . }}-backend:{{ .Values.backend.service.port }}']
+      args: ['{{ include "sde.fullname" . }}-frontend:{{ .Values.frontend.service.port }}']
   restartPolicy: Never

--- a/charts/simpledataexchanger/values.yaml
+++ b/charts/simpledataexchanger/values.yaml
@@ -28,7 +28,7 @@ sdepostgresql:
   auth:
     postgresPassword: ""
     username: "sdeuser"
-    password: "default"
+    password: ""
     database: "sdedb"
     port: 5432
     existingSecret: ""

--- a/charts/simpledataexchanger/values.yaml
+++ b/charts/simpledataexchanger/values.yaml
@@ -58,7 +58,7 @@ backend:
       drop:
         - ALL
     runAsNonRoot: true
-    runAsUser: 101
+    runAsUser: 1001
 
   service:
     type: ClusterIP

--- a/charts/simpledataexchanger/values.yaml
+++ b/charts/simpledataexchanger/values.yaml
@@ -26,7 +26,7 @@ sdepostgresql:
   enabled: true
   fullnameOverride: "product-sde-postgres"
   auth:
-    postgresPassword: "default"
+    postgresPassword: ""
     username: "sdeuser"
     password: "default"
     database: "sdedb"
@@ -58,7 +58,7 @@ backend:
       drop:
         - ALL
     runAsNonRoot: true
-    runAsUser: 1001
+    runAsUser: 101
 
   service:
     type: ClusterIP

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -1,6 +1,6 @@
 # sde
 
-![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -1,6 +1,6 @@
 # sde
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -1,6 +1,6 @@
 # sde
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -1,6 +1,6 @@
 # sde
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -12,7 +12,7 @@ A Helm chart for Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | sdepostgresql(postgresql) | 11.x.x |
+| https://charts.bitnami.com/bitnami | sdepostgresql(postgresql) | 12.x.x |
 
 ## Values
 


### PR DESCRIPTION
## Description
* PostgreSQL random password generation.
* changed to v2.3.1 docker image version.
* fixed custom user permission issue in docker image.
* Veracode vulnerability fix in AppV- 2.3.1

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
