### PR TITLE
(chore): changelog and helm version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple-Data-Exchanger helm chart.
 
+## 0.1.5
+### Change
+- changed to v2.3.6 docker image version.
+- fixed build docker image change for vulnerability issue.
+
 ## 0.1.4
 ### Change
 - changed to v2.3.5 docker image version.
 - fixed build docker image change for vulnerability issue.
 - backend configurations properties updated in values.yaml.
-
 
 ## 0.1.3
 ### Change

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -32,12 +32,12 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.3.5"
+appVersion: "2.3.6"
 
 dependencies:
   - condition: sdepostgresql.enabled


### PR DESCRIPTION
## Description

- changelog and helm v0.1.5 ,app-version update.
- Docker image version 2.3.6.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
