### PR TITLE
chore chnage log updated and release version 

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -43,7 +43,7 @@ on:
         upgrade_from:
           description: 'chart version to upgrade from'
           # chart version from 3.2 release as default
-          default: '0.1.5'
+          default: '0.1.6'
           required: false
           type: string
 
@@ -97,7 +97,7 @@ jobs:
           run: |
             helm repo add bitnami https://charts.bitnami.com/bitnami
             helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-            helm install simpledataexchanger tractusx-dev/sde --version ${{ github.event.inputs.upgrade_from || '0.1.5' }}
+            helm install simpledataexchanger tractusx-dev/sde --version ${{ github.event.inputs.upgrade_from || '0.1.6' }}
             helm dependency update charts/simpledataexchanger
             helm upgrade simpledataexchanger charts/simpledataexchanger
           if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple-Data-Exchanger helm chart.
 
+## 0.1.7
+### Change
+- changed to v2.3.8 docker image version.
+- fixed build docker image change for vulnerability issue.
+
 ## 0.1.6
 ### Change
 - changed to v2.3.7 docker image version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 
 ## 0.1.7
 ### Change
-- changed to v2.3.8 docker image version.
+- changed to v2.4.0 docker image version.
 - fixed build docker image change for vulnerability issue.
 
 ## 0.1.6

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -37,7 +37,7 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.3.8"
+appVersion: "2.4.0"
 
 dependencies:
   - condition: sdepostgresql.enabled

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -32,12 +32,12 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.3.7"
+appVersion: "2.3.8"
 
 dependencies:
   - condition: sdepostgresql.enabled

--- a/charts/simpledataexchanger/README.md
+++ b/charts/simpledataexchanger/README.md
@@ -1,6 +1,6 @@
 # sde
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.3](https://img.shields.io/badge/AppVersion-2.3.3-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.8](https://img.shields.io/badge/AppVersion-2.3.8-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/simpledataexchanger/README.md
+++ b/charts/simpledataexchanger/README.md
@@ -1,6 +1,6 @@
 # sde
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.8](https://img.shields.io/badge/AppVersion-2.3.8-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -1,6 +1,6 @@
 # sde
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.8](https://img.shields.io/badge/AppVersion-2.3.8-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -1,6 +1,6 @@
 # sde
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.8](https://img.shields.io/badge/AppVersion-2.3.8-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
## Description

- Change log updated.
- appversion --> 2.4.0
- chart version  --> 0.1.7

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
