### PR TITLE
chore updated helm-lint workflow and corrected urls

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -43,9 +43,15 @@ on:
         upgrade_from:
           description: 'chart version to upgrade from'
           # chart version from 3.2 release as default
-          default: '0.1.6'
+          default: '0.1.7'
           required: false
           type: string
+        helm_version:
+          description: 'helm version to test (default = latest)'
+          default: 'latest'
+          required: false
+          type: string
+
 
 jobs:
     lint-test:
@@ -97,7 +103,7 @@ jobs:
           run: |
             helm repo add bitnami https://charts.bitnami.com/bitnami
             helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-            helm install simpledataexchanger tractusx-dev/sde --version ${{ github.event.inputs.upgrade_from || '0.1.6' }}
+            helm install simpledataexchanger tractusx-dev/sde --version ${{ github.event.inputs.upgrade_from || '0.1.7' }}
             helm dependency update charts/simpledataexchanger
             helm upgrade simpledataexchanger charts/simpledataexchanger
           if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -37,7 +37,7 @@ on:
         node_image:
           description: 'kindest/node image for k8s kind cluster'
           # k8s version from 3.2 release as default
-          default: 'kindest/node:v1.27.3'
+          default: 'kindest/node:v1.27.13'
           required: false
           type: string
         upgrade_from:
@@ -68,7 +68,7 @@ jobs:
             # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
             version: v0.20.0
             # default value for event_name != workflow_dispatch
-            node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
+            node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.13' }}
 
         - name: Set up Helm
           uses: azure/setup-helm@v3

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -29,8 +29,8 @@ SPDX-License-Identifier: Apache-2.0
 The project maintains the following source code repositories 
 in the GitHub organization https://github.com/eclipse-tractusx:
 
-* https://github.com/catenax-ng/tx-managed-simple-data-exchanger-backend
-* https://github.com/catenax-ng/tx-managed-simple-data-exchanger-frontend
+* https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend
+* https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend
 
 
 ## Third-party Content

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To install the chart with the release name portal:
 For used licenses, please see the [NOTICE](https://github.com/eclipse-tractusx/managed-simple-data-exchanger/blob/main/NOTICE.md).
 
 ### Documentation
- Docs reference link can be found here [docs](https://github.com/catenax-ng/tx-managed-simple-data-exchanger/blob/main/docs/install.md).
+ Docs reference link can be found here [docs](https://github.com/eclipse-tractusx/managed-simple-data-exchanger/blob/main/docs/Install.md).
 
 ## Notice for Docker image
 

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -32,7 +32,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.


### PR DESCRIPTION
## Description

- updated helm-lint workflow and corrected urls.
- chart version 0.1.8.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
