### PR TITLE
chore chart updated with values.yaml for backend config.

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -43,7 +43,7 @@ on:
         upgrade_from:
           description: 'chart version to upgrade from'
           # chart version from 3.2 release as default
-          default: '0.1.7'
+          default: '0.1.8'
           required: false
           type: string
         helm_version:
@@ -103,7 +103,7 @@ jobs:
           run: |
             helm repo add bitnami https://charts.bitnami.com/bitnami
             helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-            helm install simpledataexchanger tractusx-dev/sde --version ${{ github.event.inputs.upgrade_from || '0.1.7' }}
+            helm install simpledataexchanger tractusx-dev/sde --version ${{ github.event.inputs.upgrade_from || '0.1.8' }}
             helm dependency update charts/simpledataexchanger
             helm upgrade simpledataexchanger charts/simpledataexchanger
           if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Simple-Data-Exchanger helm chart.
 
+## 0.1.9
+### Change
+- changed to v2.4.1 docker image version.
+- configuration properties added for sdebackend in value.yaml.
+
+## 0.1.8
+### Change
+- bumped in helm chart version.
+- Updated README.md.
+
 ## 0.1.7
 ### Change
 - changed to v2.4.0 docker image version.

--- a/charts/simpledataexchanger/Chart.yaml
+++ b/charts/simpledataexchanger/Chart.yaml
@@ -32,12 +32,12 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.4.0"
+appVersion: "2.4.1"
 
 dependencies:
   - condition: sdepostgresql.enabled

--- a/charts/simpledataexchanger/values.yaml
+++ b/charts/simpledataexchanger/values.yaml
@@ -188,6 +188,9 @@ backend:
       policy.hub.clientId=default
       policy.hub.clientSecret=default
       policy.hub.grantType=client_credentials
+      bpdm.provider.edc.dataspace.api=default
+      bpdm.provider.bpnl=default
+      bpdm.provider.edc.public.api=default
 
 frontend:
   image:


### PR DESCRIPTION
## Description

- backend configs added in values.yaml.
- chart version & app version bump. chart version -> 0.1.9, appversion -> 2.4.1

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
