### PR TITLE
chore: pin GitHub Actions workflows to immutable SHA digests

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # fetch-depth: 0 is required to determine differences in chart(s)
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@eef6142e2b95616222b07d579f323a1a36746862 # v3.5.3
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@fe7b40cdcaf2037de0f88569da3a964a5d3d1912 # v3.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       
@@ -59,6 +59,6 @@ jobs:
           helm dependency update
   
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@a3454e40a1f5a53e1aa202601397d0224a77114e # v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -58,12 +58,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@eef6142e2b95616222b07d579f323a1a36746862 # v3.5.3
           with:
             fetch-depth: 0
 
         - name: Kubernetes KinD Cluster
-          uses: container-tools/kind-action@v1
+          uses: container-tools/kind-action@28302066a3d671c098935579919f96b9f6580540 # v1.7.0
           with:
             # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
             version: v0.20.0
@@ -71,15 +71,15 @@ jobs:
             node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.13' }}
 
         - name: Set up Helm
-          uses: azure/setup-helm@v3
+          uses: azure/setup-helm@fe7b40cdcaf2037de0f88569da3a964a5d3d1912 # v3.5
 
       # Setup python as a prerequisite for chart linting 
-        - uses: actions/setup-python@v4
+        - uses: actions/setup-python@65d7f2d534c06c906214d89671d7912d7c0064f7 # v4.7.1
           with:
             python-version: 3.9
 
         - name: Set up chart-testing
-          uses: helm/chart-testing-action@v2.3.1
+          uses: helm/chart-testing-action@afea3465360938f36c53e80f8231e670220668f4 # v2.3.1
 
         - name: Run chart-testing (list-changed)
           id: list-changed
@@ -107,6 +107,3 @@ jobs:
             helm dependency update charts/simpledataexchanger
             helm upgrade simpledataexchanger charts/simpledataexchanger
           if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
-
-
-

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -42,10 +42,10 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@eef6142e2b95616222b07d579f323a1a36746862 # v3.5.3
 
       - name: KICS scan
-        uses: checkmarx/kics-github-action@master
+        uses: checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6 # v2.1.20
         with:
           # Scanning directory .
           path: "."
@@ -69,7 +69,6 @@ jobs:
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@df409f7d9383ac742e9bc967727449bc3394c2ed # v2.22.5
         with:
           sarif_file: kicsResults/results.sarif
-          

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -42,13 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@8a8ef8526527dd5f5d731d8e74843c121777b82d # v3.80.2
         continue-on-error: true
         with:
           path: ./  # Scan the entire repository
@@ -57,4 +57,4 @@ jobs:
       
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'
-        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets 
+        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

This PR replaces all mutable GitHub Actions version references (e.g. `@master`, `@main`, and floating tags like `@v3`) in `.github/workflows/` with **immutable, SHA-pinned** references. This is a supply-chain security hardening measure.

### :warning: Why this matters

Using mutable version tags means your CI/CD pipeline silently executes **whatever code an action's maintainer - or an attacker who has compromised their account - pushes** to that branch or tag at any point in time.

Pinning to a full 40-character commit SHA provides:

- **Immutability** - the exact same code runs on every workflow invocation, regardless of upstream tag moves or branch force-pushes
- **Auditability** - any version change is immediately visible in a diff
- **Compliance** - aligns with [OpenSSF Scorecard](https://securityscorecards.dev) "Pinned-Dependencies" check and SLSA supply-chain security guidelines

### Changes introduced in this PR

The following action references in this repository have been replaced. A human-readable version comment is retained next to each SHA for maintainability.

| Workflow File | Old Reference | New SHA-Pinned Reference | Resolved Version |
| --- | --- | --- | --- |
| `.github/workflows/kics.yml` | `checkmarx/kics-github-action@master` | `checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6` | v2.1.20 |
| `.github/workflows/trufflehog.yml` | `trufflesecurity/trufflehog@main` | `trufflesecurity/trufflehog@8a8ef8526527dd5f5d731d8e74843c121777b82d` | v3.80.2 |
| `.github/workflows/chart-release.yml` | `azure/setup-helm@v3` | `azure/setup-helm@fe7b40cdcaf2037de0f88569da3a964a5d3d1912` | v3.5 |
| `.github/workflows/chart-release.yml` | `helm/chart-releaser-action@v1.4.1` | `helm/chart-releaser-action@a3454e40a1f5a53e1aa202601397d0224a77114e` | v1.4.1 |
| `.github/workflows/helm-lint.yml` | `container-tools/kind-action@v1` | `container-tools/kind-action@28302066a3d671c098935579919f96b9f6580540` | v1.7.0 |
| `All files` | `actions/checkout@v3` | `actions/checkout@eef6142e2b95616222b07d579f323a1a36746862` | v3.5.3 |
| `trufflehog.yml` | `actions/checkout@v4` | `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` | v4.2.2 |

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files